### PR TITLE
Add self-hit penalty in training

### DIFF
--- a/__tests__/game.test.js
+++ b/__tests__/game.test.js
@@ -1,4 +1,4 @@
-const { WEAPONS } = require('../assets/js/game');
+const { WEAPONS, simulateShot } = require('../assets/js/game');
 
 test('weapon configuration includes mega blast damage', () => {
   expect(WEAPONS.mega.damage).toBe(50);
@@ -12,4 +12,15 @@ test('weapon keys', () => {
     'bouncy',
     'mega',
   ]);
+});
+
+test('simulateShot penalizes self hits', () => {
+  const net = {
+    hiddenWeights: Array.from({ length: 3 }, () => Array(5).fill(0)),
+    hiddenBias: Array(3).fill(0),
+    outputWeights: Array.from({ length: 7 }, () => Array(3).fill(0)),
+    outputBias: [1, -1, 0, 0, 0, 0, 0],
+  };
+  const score = simulateShot(net, 300);
+  expect(score).toBeLessThan(0);
 });

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -136,12 +136,18 @@ function simulateShot(net, enemyX) {
     const t = (vy * 2) / GRAVITY;
     const landingX = vx * t;
     const dist = Math.abs(landingX - enemyX);
+    // distance from the firing tank's position at x=0
+    const selfDist = Math.abs(landingX);
     let damage = 0;
     if (dist <= w.radius) {
         damage = w.damage * (1 - dist / w.radius);
     }
+    let selfDamage = 0;
+    if (selfDist <= w.radius) {
+        selfDamage = w.damage * (1 - selfDist / w.radius);
+    }
     const closeness = Math.max(0, (w.radius - dist) / w.radius);
-    return damage + closeness * 10;
+    return damage + closeness * 10 - selfDamage;
 }
 
 function evaluate(net) {
@@ -616,6 +622,9 @@ if (typeof module !== 'undefined') {
         loadTrainedNet,
         evolve,
         startBackgroundTraining,
+        // expose for testing
+        evaluate,
+        simulateShot,
     };
 } else {
     window.onload = () => {


### PR DESCRIPTION
## Summary
- penalize AI tanks for hitting themselves during training
- expose `simulateShot` and `evaluate` for tests
- test that self-hits yield a negative score

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877cdf2a4cc8323954ffa9de3a30f05