### PR TITLE
Add wind physics with sensor input

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ node train.js
 The script evolves neural networks and saves the best network to `trained_net.json`.
 The game will automatically load this file for AI tanks if it exists.
 
+### Wind
+
+Each round features a random wind value that influences projectile paths. The AI
+tanks receive the current wind as a sensor input and the training simulation
+accounts for it as well.
+


### PR DESCRIPTION
## Summary
- simulate wind force that changes each round
- add wind as a sensor input
- incorporate wind into training simulation
- document wind feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877fcbc500c83238476eba30b353f6c