### PR TITLE
Add initGame test with canvas stub

### DIFF
--- a/__tests__/game.test.js
+++ b/__tests__/game.test.js
@@ -1,5 +1,6 @@
 let generateTerrain;
 let getTerrainY;
+let initGame;
 
 describe('terrain utility', () => {
   beforeAll(() => {
@@ -7,7 +8,9 @@ describe('terrain utility', () => {
       <canvas id="gameCanvas" width="1000" height="600"></canvas>
       <div id="stats"></div>
     `;
-    ({ generateTerrain, getTerrainY } = require('../assets/js/game'));
+    const canvas = document.getElementById('gameCanvas');
+    canvas.getContext = jest.fn(() => ({}));
+    ({ generateTerrain, getTerrainY, initGame } = require('../assets/js/game'));
   });
 
   beforeEach(() => {
@@ -22,5 +25,9 @@ describe('terrain utility', () => {
   test('getTerrainY returns canvas height for out of bounds x', () => {
     expect(getTerrainY(-10)).toBe(600);
     expect(getTerrainY(2000)).toBe(600);
+  });
+
+  test('initGame runs without throwing', () => {
+    expect(() => initGame()).not.toThrow();
   });
 });

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -617,6 +617,7 @@ if (
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         generateTerrain,
-        getTerrainY
+        getTerrainY,
+        initGame
     };
 }


### PR DESCRIPTION
## Summary
- stub `getContext` for canvas in the tests
- export `initGame` from the game module
- test that `initGame` runs without errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687808cdb160832388b2437a0cde75a7