### PR TITLE
Fix fitness calc & add training test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+trained_net.json

--- a/__tests__/train.test.js
+++ b/__tests__/train.test.js
@@ -1,0 +1,6 @@
+const { train, getGlobalBestFitness } = require('../train');
+
+test('training improves fitness', () => {
+  train(10);
+  expect(getGlobalBestFitness()).toBeGreaterThan(0);
+});

--- a/train.js
+++ b/train.js
@@ -123,7 +123,7 @@ function simulateTraining() {
         const target = simTanks.find(t => t.id !== tank.id && t.alive);
         if (target) {
           const distance = Math.hypot(target.x - tank.x, target.y - tank.y);
-          tank.fitness += Math.max(0, 100 - distance);
+          tank.fitness += Math.max(0, 1000 - distance);
         }
       });
     }
@@ -153,7 +153,16 @@ function train(generations) {
     JSON.stringify(globalBestModel.toJSON(), null, 2)
   );
   console.log('Saved weights to trained_net.json');
+  return globalBestFitness;
 }
 
-const gens = parseInt(process.argv[2], 10) || 500;
-train(gens);
+if (require.main === module) {
+  const gens = parseInt(process.argv[2], 10) || 500;
+  train(gens);
+}
+
+module.exports = {
+  train,
+  simulateTraining,
+  getGlobalBestFitness: () => globalBestFitness
+};


### PR DESCRIPTION
## Summary
- handle large distances in training fitness calculation
- export train helpers in `train.js`
- add `.gitignore` entry for generated weight files
- verify training yields positive fitness in new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878113392cc8323919e9a7474f1e96f